### PR TITLE
Add mozilla to user agent test

### DIFF
--- a/skip-link-focus.js
+++ b/skip-link-focus.js
@@ -29,7 +29,7 @@
 		options = options || {};
 		options.selector = options.selector || '.skip-link';
 
-		if ( window && /webkit|opera|msie|trident/i.test( navigator.userAgent ) && window.addEventListener ) {
+		if ( window && /webkit|opera|msie|mozilla|trident/i.test( navigator.userAgent ) && window.addEventListener ) {
 			var i,
 				skipLinks = window.document.querySelectorAll( options.selector );
 


### PR DESCRIPTION
The skip link does not work on Firefox. We included the Mozilla agent string.